### PR TITLE
feat(skin api): create skin api

### DIFF
--- a/src/main/java/gg/phast/helios/mojang/HeliosSkinManager.java
+++ b/src/main/java/gg/phast/helios/mojang/HeliosSkinManager.java
@@ -1,0 +1,94 @@
+package gg.phast.helios.mojang;
+
+import com.google.common.base.Preconditions;
+import com.mojang.authlib.GameProfile;
+import com.mojang.authlib.properties.Property;
+import gg.phast.helios.mojang.textures.SkinData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+/**
+ * Skin Manager for managing player's textures
+ * in more intuitive way to speed up
+ * workflow
+ *
+ * @author phastgg
+ * @since 1.1
+ */
+public class HeliosSkinManager {
+
+    private static final HeliosSkinManager SINGLETON = new HeliosSkinManager();
+
+    private final MojangService mojangService;
+
+    private HeliosSkinManager() {
+        mojangService = new MojangService();
+    }
+
+    /**
+     * Changes GameProfile's textures to the ones specified
+     *
+     * @param profile profile
+     * @param skinData new textures
+     */
+    public void changeSkinDataFor(@NotNull GameProfile profile, @NotNull SkinData skinData) {
+        Preconditions.checkNotNull(profile, "profile cannot be null");
+        Preconditions.checkNotNull(skinData, "skinData cannot be null");
+
+        clearSkinDataFor(profile);
+        profile.properties().put("textures", new Property("textures", skinData.getTexture(), skinData.getSignature()));
+    }
+
+    /**
+     * Changes GameProfile's textures to the ones of specified player
+     *
+     * @param profile profile
+     * @param playerName from which player to fetch textures
+     */
+    public void changeSkinDataFor(@NotNull GameProfile profile, @NotNull String playerName) throws URISyntaxException, IOException {
+        Preconditions.checkNotNull(profile, "profile cannot be null");
+        Preconditions.checkNotNull(playerName, "playerName cannot be null");
+
+        clearSkinDataFor(profile);
+
+        SkinData skinData = requestSkinDataFor(playerName);
+        boolean skinFound = skinData != null;
+
+        Preconditions.checkState(skinFound, "skinData not found for %s", playerName);
+
+        changeSkinDataFor(profile, skinData);
+    }
+
+    /**
+     * Clears all textures from GameProfile
+     *
+     * @param profile profile
+     */
+    public void clearSkinDataFor(@NotNull GameProfile profile) {
+        Preconditions.checkNotNull(profile, "profile cannot be null");
+
+        profile.properties().removeAll("textures");
+    }
+
+    /**
+     * Requests for textures from Mojang API using {@link MojangService}
+     *
+     * @param playerName player name
+     * @return SkinData returned from Mojang API, can be null and should be used with this in mind
+     */
+    public @Nullable SkinData requestSkinDataFor(@NotNull String playerName) throws URISyntaxException, IOException {
+        return mojangService.requestTexturesForPlayer(playerName);
+    }
+
+    /**
+     * Gets singleton instance of this class
+     *
+     * @return singleton instance
+     */
+    public static HeliosSkinManager getInstance() {
+        return SINGLETON;
+    }
+}

--- a/src/main/java/gg/phast/helios/mojang/MojangService.java
+++ b/src/main/java/gg/phast/helios/mojang/MojangService.java
@@ -1,0 +1,56 @@
+package gg.phast.helios.mojang;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import gg.phast.helios.mojang.textures.SkinData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * Mojang Service specifically crafted
+ * for Mojang's API, therefore can be unstable
+ *
+ * @author phastgg
+ * @since 1.1
+ */
+class MojangService {
+
+    private static final String PROFILE_LOOKUP_URL = "https://api.mojang.com/users/profiles/minecraft/{NAME}";
+    private static final String SESSION_LOOKUP_URL = "https://sessionserver.mojang.com/session/minecraft/profile/{UUID}?unsigned=false";
+
+    public @Nullable SkinData requestTexturesForPlayer(@NotNull String target) throws URISyntaxException, IOException {
+        URL profileUrl = new URI(PROFILE_LOOKUP_URL.replace("{NAME}", target)).toURL();
+        String uuid;
+
+        // response for profile lookup
+        try (InputStream response = profileUrl.openStream(); InputStreamReader responseReader = new InputStreamReader(response)) {
+            uuid = JsonParser
+                    .parseReader(responseReader)
+                    .getAsJsonObject()
+                    .get("id")
+                    .getAsString();
+        }
+
+        URL sessionUrl = new URI(SESSION_LOOKUP_URL.replace("{UUID}", uuid)).toURL();
+        JsonObject sessionObject;
+        // response for session lookup
+        try (InputStream response = sessionUrl.openStream(); InputStreamReader responseReader = new InputStreamReader(response)) {
+            sessionObject = JsonParser
+                    .parseReader(responseReader)
+                    .getAsJsonObject()
+                    .get("properties")
+                    .getAsJsonArray()
+                    .get(0)
+                    .getAsJsonObject();
+        }
+
+        return SkinData.of(sessionObject);
+    }
+}

--- a/src/main/java/gg/phast/helios/mojang/textures/SkinData.kt
+++ b/src/main/java/gg/phast/helios/mojang/textures/SkinData.kt
@@ -1,0 +1,36 @@
+package gg.phast.helios.mojang.textures
+
+import com.google.gson.JsonObject
+import com.mojang.authlib.properties.Property
+
+/**
+ * SkinData simple wrapper holding texture and signature
+ *
+ * @author phastgg
+ * @since 1.1
+ */
+data class SkinData(val texture: String, val signature: String) {
+    companion object {
+        @JvmStatic
+        fun of(texture: String, signature: String): SkinData {
+            return SkinData(texture, signature)
+        }
+
+        @JvmStatic
+        fun of(jsonObject: JsonObject): SkinData {
+            return of(
+                jsonObject.get("value").asString,
+                jsonObject.get("signature").asString
+            );
+        }
+
+        @JvmStatic
+        fun of(property: Property): SkinData {
+            return of(
+                property.value,
+                property.signature!!
+            );
+        }
+    }
+
+}


### PR DESCRIPTION
Goal of this API is to make managing of Player's skins easier and more intuitive. It offers a list of options to manage skins without the required extra boilerplate.